### PR TITLE
Corrected command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
     git clone https://github.com/xeroc/python-bitsharesrpc
     cd python-bitsharesrpc
-    python setup install    # (optionally with parameter --user fo non-root installations)
+    python setup.py install    # (optionally with parameter --user fo non-root installations)
 
 **Configuration**
 


### PR DESCRIPTION
On OS X, I received an error with the original CLI argument: 
```
python: can't open file 'setup': [Errno 2] No such file or directory
```
Adding .py fixed the problem.